### PR TITLE
can now delete own jokes from edit page

### DIFF
--- a/ChuckleBucket/Controllers/JokeController.cs
+++ b/ChuckleBucket/Controllers/JokeController.cs
@@ -94,6 +94,14 @@ namespace ChuckleBucket.Controllers
             return NoContent();
         }
 
+        [Authorize]
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            _jokeRepository.Remove(id);
+            return NoContent();
+        }
+
         private UserProfile GetCurrentUserProfile()
         {
             var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;

--- a/ChuckleBucket/Repositories/IJokeRepository.cs
+++ b/ChuckleBucket/Repositories/IJokeRepository.cs
@@ -11,5 +11,6 @@ namespace ChuckleBucket.Repositories
         List<Joke> GetJokesByAuthorId(int authorId);
         void Add(Joke joke);
         void Update(Joke joke);
+        void Remove(int id);
     }
 }

--- a/ChuckleBucket/Repositories/JokeRepository.cs
+++ b/ChuckleBucket/Repositories/JokeRepository.cs
@@ -172,6 +172,22 @@ namespace ChuckleBucket.Repositories
             }
         }
 
+        public void Remove(int id)
+        {
+            using(SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using(SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"DELETE FROM Joke
+                                        WHERE Id = @id";
+                    DbUtils.AddParameter(cmd, "@id", id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
         public Joke NewJokeFromReader(SqlDataReader reader)
         {
             return new Joke

--- a/ChuckleBucket/client/src/components/jokes/EditJoke.js
+++ b/ChuckleBucket/client/src/components/jokes/EditJoke.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button, Form, FormFeedback, FormGroup, Input, Label } from "reactstrap";
 import { getAllCategories } from "../../modules/categoriesManager";
-import { getJokeById, updateJoke } from "../../modules/jokesManager";
+import { deleteJoke, getJokeById, updateJoke } from "../../modules/jokesManager";
 
 
 const EditJoke = ({ userData }) => {
@@ -12,6 +12,7 @@ const EditJoke = ({ userData }) => {
     const [jokeId, setJokeId] = useState(0);
     const [categories, setCategories] = useState([]);
     const [textInvalid, setTextInvalid] = useState(false);
+    const [confirmDelete, setConfirmDelete] = useState(false);
 
     const { id } = useParams();
 
@@ -54,6 +55,14 @@ const EditJoke = ({ userData }) => {
         }).then(() => { navigate("/jokes/my") })
     }
 
+    const handleDelete = (event) => {
+        event.preventDefault();
+        deleteJoke(jokeId)
+            .then(() => {
+                navigate("/jokes/my")
+            })
+    }
+
     if (userData.id !== authorId) {
         return <h3>Whoops!  You are not authorized to edit this joke.</h3>;
     }
@@ -88,7 +97,13 @@ const EditJoke = ({ userData }) => {
                     </Input>
                 </FormGroup>
                 <Button onClick={handleSubmit}>Submit</Button>
+                {' '}
                 <Button onClick={() => { navigate("/jokes/my") }}>Cancel</Button>
+                {' '}
+                {confirmDelete ? <>Delete? <Button onClick={handleDelete} color="danger">Yes</Button>
+                    <Button onClick={() => { setConfirmDelete(false) }}>No</Button></>
+                    : <Button color="danger" onClick={() => { setConfirmDelete(true) }}>Delete</Button>}
+
             </Form>
         </>
     )

--- a/ChuckleBucket/client/src/modules/jokesManager.js
+++ b/ChuckleBucket/client/src/modules/jokesManager.js
@@ -87,3 +87,14 @@ export const updateJoke = (id, joke) => {
         })
     })
 }
+
+export const deleteJoke = (id) => {
+    return getToken().then(token => {
+        return fetch(`${baseUrl}/${id}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        })
+    })
+}


### PR DESCRIPTION
closes #9 

Now a delete button appears on the edit page.  User is first prompted to confirm deletion and then the joke is deleted after clicking "yes".

Tested by deleting multiple jokes.