### PR TITLE
can now view favorites page

### DIFF
--- a/ChuckleBucket/Controllers/JokeController.cs
+++ b/ChuckleBucket/Controllers/JokeController.cs
@@ -66,10 +66,15 @@ namespace ChuckleBucket.Controllers
         {
             UserProfile currentUser = GetCurrentUserProfile();
             List<Joke> jokes = _jokeRepository.GetJokesByAuthorId(currentUser.Id);
-            if (jokes == null)
-            {
-                return NotFound();
-            }
+            return Ok(jokes);
+        }
+
+        [Authorize]
+        [HttpGet("favorites")]
+        public IActionResult GetFavorites()
+        {
+            UserProfile currentUser = GetCurrentUserProfile();
+            List<Joke> jokes = _jokeRepository.GetFavoriteJokes(currentUser.Id);
             return Ok(jokes);
         }
 

--- a/ChuckleBucket/Repositories/IJokeRepository.cs
+++ b/ChuckleBucket/Repositories/IJokeRepository.cs
@@ -15,5 +15,6 @@ namespace ChuckleBucket.Repositories
         void AddLaugh(int jokeId, int userId);
         List<Laugh> GetLaughsByUserId(int userId);
         void RemoveLaugh(int jokeId, int userId);
+        List<Joke> GetFavoriteJokes(int userId);
     }
 }

--- a/ChuckleBucket/client/src/components/ApplicationViews.js
+++ b/ChuckleBucket/client/src/components/ApplicationViews.js
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import ListCategories from "./categories/ListCategories";
 import EditJoke from "./jokes/EditJoke";
+import Favorites from "./jokes/Favorites";
 import Home from "./jokes/Home";
 import JokeAuthor from "./jokes/JokeAuthor";
 import JokeCategory from "./jokes/JokeCategory";
@@ -31,6 +32,7 @@ const ApplicationViews = ({ isLoggedIn, setUserData, userData }) => {
                 <Route path="jokes/my" element={isLoggedIn ? <MyJokes userData={userData} /> : <Navigate to="/login" />} />
                 <Route path="jokes/new" element={isLoggedIn ? <JokeForm userData={userData} /> : <Navigate to="/login" />} />
                 <Route path="jokes/edit/:id" element={isLoggedIn ? <EditJoke userData={userData} /> : <Navigate to="/login" />} />
+                <Route path="jokes/favorite" element={isLoggedIn ? <Favorites userData={userData} /> : <Navigate to="/login" />} />
 
                 <Route path="profile" element={isLoggedIn ? <MyProfile userData={userData} /> : <Navigate to="/login" />} />
                 <Route path="profile/edit" element={isLoggedIn ? <EditProfile userData={userData} /> : <Navigate to="/login" />} />

--- a/ChuckleBucket/client/src/components/jokes/Favorites.js
+++ b/ChuckleBucket/client/src/components/jokes/Favorites.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { getFavoriteJokes } from "../../modules/jokesManager";
+import ListJokes from "./ListJokes";
+
+
+
+const Favorites = ({ userData }) => {
+    const [jokes, setJokes] = useState([]);
+
+    const getJokes = () => {
+        getFavoriteJokes()
+            .then(jokesData => {
+                setJokes(jokesData);
+            })
+    }
+
+    useEffect(() => {
+        getJokes();
+    }, [])
+
+    return (
+        <>
+            <h1>My Favorites</h1>
+            <ListJokes jokes={jokes} userData={userData} getJokes={getJokes} />
+        </>
+    )
+}
+
+export default Favorites;

--- a/ChuckleBucket/client/src/components/jokes/MyJokes.js
+++ b/ChuckleBucket/client/src/components/jokes/MyJokes.js
@@ -25,6 +25,7 @@ const MyJokes = ({ userData }) => {
         <>
             <h1>My Jokes</h1>
             <Button onClick={() => { navigate("/jokes/new") }}>Create New</Button>
+            <Button onClick={() => { navigate("/jokes/favorite") }}>Favorites</Button>
             <ListJokes jokes={jokes} userData={userData} getJokes={getJokes} />
         </>
     )

--- a/ChuckleBucket/client/src/modules/jokesManager.js
+++ b/ChuckleBucket/client/src/modules/jokesManager.js
@@ -62,6 +62,18 @@ export const getJokesByCurrentUser = () => {
     })
 }
 
+export const getFavoriteJokes = () => {
+    return getToken().then(token => {
+        return fetch(`${baseUrl}/favorites`, {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        })
+            .then(res => res.json())
+    })
+}
+
 export const addJoke = (joke) => {
     return getToken().then(token => {
         return fetch(baseUrl, {


### PR DESCRIPTION
closes #14 

When viewing My Jokes, a user can click the Favorites button and be taken to a list of all jokes they have previously "Laughed" at.  If they un-laugh a  joke it will be removed from the favorites page.

Tested by laughing at multiple jokes, then navigating to the Favorites page and verifying their presence.  Also tested responsiveness by un-laughing jokes to see if they are removed from the list.  