### PR TITLE
refreshing the page no longer redirects to login

### DIFF
--- a/ChuckleBucket/client/src/App.js
+++ b/ChuckleBucket/client/src/App.js
@@ -5,6 +5,7 @@ import { onLoginStatusChange } from './modules/authManager';
 import { BrowserRouter } from 'react-router-dom';
 import Header from './components/Header';
 import ApplicationViews from './components/ApplicationViews';
+import { Spinner } from 'reactstrap';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(null);
@@ -14,6 +15,10 @@ function App() {
     onLoginStatusChange(setIsLoggedIn);
   }, []);
 
+  if (isLoggedIn === null) {
+    // Until we know whether or not the user is logged in or not, just show a spinner
+    return <Spinner className="app-spinner dark" />;
+  }
 
   return (
     <div className="App">


### PR DESCRIPTION
closes #21 

Page now reloads normally.  Had to add the code returning the spinner in app.js forcing the application to wait until isLoggedIn is no longer null.

Tested by reloading the page.